### PR TITLE
Sửa lại API lấy dữ liệu thiết bị trong nhà

### DIFF
--- a/src/main/java/com/hust/khanhkelvin/repository/SensorDataRepository.java
+++ b/src/main/java/com/hust/khanhkelvin/repository/SensorDataRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Repository
 public interface SensorDataRepository extends JpaRepository<SensorDataEntity, Long> {
 
-    @Query("from SensorDataEntity sde where sde.houseSensorId in (:houseSensorIds)")
+    @Query("from SensorDataEntity sde where sde.houseSensorId in (:houseSensorIds) and sde.id in (" +
+            "select max(id) from SensorDataEntity group by houseSensorId)")
     List<SensorDataEntity> findAllByHouseSensorIds(List<Long> houseSensorIds);
 }

--- a/src/main/java/com/hust/khanhkelvin/service/impl/SensorDataServiceImpl.java
+++ b/src/main/java/com/hust/khanhkelvin/service/impl/SensorDataServiceImpl.java
@@ -66,19 +66,16 @@ public class SensorDataServiceImpl implements SensorDataService {
         // List HUMIDITY
         List<SensorDataEntity> dataHumidities = sensorDataEntities.stream()
                 .filter(data -> Objects.equals(data.getSensorType(), SensorType.HUMIDITY))
-                .limit(10)
                 .collect(Collectors.toList());
 
         // List THERMOMETER
         List<SensorDataEntity> dataThermoeter = sensorDataEntities.stream()
                 .filter(data -> Objects.equals(data.getSensorType(), SensorType.THERMOMETER))
-                .limit(10)
                 .collect(Collectors.toList());
 
         // List GAS CONCENTRATION
         List<SensorDataEntity> dataGasConcentration = sensorDataEntities.stream()
                 .filter(data -> Objects.equals(data.getSensorType(), SensorType.GAS_CONCENTRATION))
-                .limit(10)
                 .collect(Collectors.toList());
 
         // List door
@@ -105,7 +102,6 @@ public class SensorDataServiceImpl implements SensorDataService {
         // List led
         List<SensorDataEntity> dataLeds = sensorDataEntities.stream()
                 .filter(data -> Objects.equals(data.getSensorType(), SensorType.LED))
-                .limit(10)
                 .collect(Collectors.toList());
 
         response.put(SensorType.LED.name(), sensorDataMapper.toDto(dataLeds));


### PR DESCRIPTION
Tôi đã sửa lại truy vấn của SensorDataRepository khi lấy danh sách dữ liệu thiết bị. Trước khi sửa thì lấy dữ liệu thiết bị trả về tất cả những dữ liệu kể cả duplicate , thêm group by vào để chỉ lấy dữ liệu của thiết bị ở lần cập nhật mới nhất.